### PR TITLE
Add OpenAI settings

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -58,4 +58,6 @@ extension Defaults.Keys {
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
   static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: false)
+  static let openAIKey = Key<String>("openAIKey", default: "")
+  static let openAIPrompt = Key<String>("openAIPrompt", default: "")
 }

--- a/Maccy/Settings/AdvancedSettingsPane.swift
+++ b/Maccy/Settings/AdvancedSettingsPane.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import Defaults
 
 struct AdvancedSettingsPane: View {
+  @Default(.openAIKey) private var openAIKey
+  @Default(.openAIPrompt) private var openAIPrompt
+
   var body: some View {
     VStack(alignment: .leading) {
       Defaults.Toggle(key: .ignoreEvents) {
@@ -37,6 +40,15 @@ struct AdvancedSettingsPane: View {
       Defaults.Toggle(key: .clearSystemClipboard) {
         Text("ClearSystemClipboard", tableName: "AdvancedSettings")
       }.help(Text("ClearSystemClipboardTooltip", tableName: "AdvancedSettings"))
+
+      HStack {
+        Text("OpenAIAPIKey", tableName: "AdvancedSettings")
+        TextField("", text: $openAIKey)
+      }
+      HStack {
+        Text("Prompt", tableName: "AdvancedSettings")
+        TextField("", text: $openAIPrompt)
+      }
     }
     .frame(minWidth: 350, maxWidth: 450)
     .padding()

--- a/Maccy/Settings/en.lproj/AdvancedSettings.strings
+++ b/Maccy/Settings/en.lproj/AdvancedSettings.strings
@@ -8,3 +8,5 @@
 "ClearHistoryOnQuitTooltip" = "Automatically remove all unpinned items before quitting the application.";
 "ClearSystemClipboard" = "Clear the system clipboard too";
 "ClearSystemClipboardTooltip" = "When enabled, clearing the history would also clear the current system clipboard.";
+"OpenAIAPIKey" = "OpenAI API Key";
+"Prompt" = "Prompt";


### PR DESCRIPTION
## Summary
- define `openAIKey` and `openAIPrompt` defaults
- expose text fields for them in **Advanced** settings pane
- localize new strings in English resources

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840510f5d38832584af9ebf6034888e