### PR TITLE
Fix Sendable warning

### DIFF
--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -4,7 +4,7 @@ import Foundation
 import Settings
 
 @Observable
-class AppState: Sendable {
+final class AppState: @unchecked Sendable {
   static let shared = AppState()
 
   var appDelegate: AppDelegate?


### PR DESCRIPTION
## Summary
- mark `AppState` as `@unchecked Sendable` and `final`

## Testing
- `swiftc /tmp/Test.swift`

------
https://chatgpt.com/codex/tasks/task_e_68405635233c8325951a451d93ff0d9f