### PR TITLE
Fix sandbox network access issue

### DIFF
--- a/Maccy/Maccy.entitlements
+++ b/Maccy/Maccy.entitlements
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-only</key>
+        <true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
     	<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>


### PR DESCRIPTION
## Summary
- enable network permissions for Maccy by adding `com.apple.security.network.client`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684063548cbc8325ae41f330d98efc6d