### PR TITLE
Fix AI response loop in clipboard handling

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -66,6 +66,9 @@ class Clipboard {
   func copy(_ string: String) {
     pasteboard.clearContents()
     pasteboard.setString(string, forType: .string)
+    // Mark that the copy originates from Maccy so that it's not processed
+    // by AI again on the next clipboard change check.
+    pasteboard.setString("", forType: .fromMaccy)
     sync()
     checkForChangesInPasteboard()
   }

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -243,6 +243,13 @@ class ClipboardTests: XCTestCase {
     XCTAssertNil(pasteboard.data(forType: .rtf))
   }
 
+  @MainActor
+  func testCopyStringMarksFromMaccy() {
+    clipboard.copy("foo")
+    XCTAssertEqual(pasteboard.string(forType: .string), "foo")
+    XCTAssertEqual(pasteboard.string(forType: .fromMaccy), "")
+  }
+
   func testHandlesItemsWithoutData() {
     let hookExpectation = expectation(description: "Hook is called")
     pasteboard.clearContents()


### PR DESCRIPTION
## Summary
- mark `copy(_: String)` entries as coming from Maccy
- add test verifying the marker is set

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684065c8cd488325b2a7346499dd9b8b