### PR TITLE
Remove unnecessary await

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -229,7 +229,7 @@ class Clipboard {
       Task {
         do {
           let result = try await OpenAI.chat(prompt: prompt, text: text, apiKey: Defaults[.openAIKey])
-          await Clipboard.shared.copy(result)
+          Clipboard.shared.copy(result)
         } catch {
           NSLog("Failed to process AI: \(error)")
         }


### PR DESCRIPTION
## Summary
- fix compile error by calling `Clipboard.shared.copy` synchronously

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68406668725083259b3f7d410d709ae1