### PR TITLE
Add notification for OpenAI responses

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -236,6 +236,7 @@ class Clipboard {
           await MainActor.run {
             AppState.shared.aiRequestRunning = false
             Clipboard.shared.copy(result)
+            Notifier.notify(body: result.shortened(to: 100), sound: .write)
           }
         } catch {
           await MainActor.run { AppState.shared.aiRequestRunning = false }


### PR DESCRIPTION
## Summary
- notify user when processed OpenAI text is copied to the clipboard

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684073f1e5fc832599cb29cb7b4e8fff