### PR TITLE
Add GPT-4o image OCR feature

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -226,20 +226,46 @@ class Clipboard {
     if Defaults[.aiEnabled],
        !Defaults[.openAIKey].isEmpty,
        !Defaults[.openAIPrompt].isEmpty,
-       !(pasteboard.types?.contains(.fromMaccy) ?? false),
-       let text = pasteboard.string(forType: .string) {
+       !(pasteboard.types?.contains(.fromMaccy) ?? false) {
       let prompt = Defaults[.openAIPrompt]
-      Task {
-        await MainActor.run { AppState.shared.aiRequestRunning = true }
-        do {
-          let result = try await OpenAI.chat(prompt: prompt, text: text, apiKey: Defaults[.openAIKey])
-          await MainActor.run {
-            AppState.shared.aiRequestRunning = false
-            Clipboard.shared.copy(result)
+      if let text = pasteboard.string(forType: .string) {
+        Task {
+          await MainActor.run { AppState.shared.aiRequestRunning = true }
+          do {
+            let result = try await OpenAI.chat(prompt: prompt, text: text, apiKey: Defaults[.openAIKey])
+            await MainActor.run {
+              AppState.shared.aiRequestRunning = false
+              Clipboard.shared.copy(result)
+            }
+          } catch {
+            await MainActor.run { AppState.shared.aiRequestRunning = false }
+            NSLog("Failed to process AI: \(error)")
           }
-        } catch {
-          await MainActor.run { AppState.shared.aiRequestRunning = false }
-          NSLog("Failed to process AI: \(error)")
+        }
+      } else if let data = pasteboard.data(forType: .png)
+                    ?? pasteboard.data(forType: .tiff)
+                    ?? pasteboard.data(forType: .jpeg)
+                    ?? pasteboard.data(forType: .heic) {
+        var pngData = data
+        if let image = NSImage(data: data),
+           let tiff = image.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiff),
+           let converted = bitmap.representation(using: .png, properties: [:]) {
+          pngData = converted
+        }
+
+        Task {
+          await MainActor.run { AppState.shared.aiRequestRunning = true }
+          do {
+            let result = try await OpenAI.chat(prompt: prompt, imageData: pngData, apiKey: Defaults[.openAIKey])
+            await MainActor.run {
+              AppState.shared.aiRequestRunning = false
+              Clipboard.shared.copy(result)
+            }
+          } catch {
+            await MainActor.run { AppState.shared.aiRequestRunning = false }
+            NSLog("Failed to process AI: \(error)")
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- support sending images to GPT‑4o by extending `OpenAI` helper
- detect copied images and send them to GPT‑4o to extract text

## Testing
- `swiftc -typecheck Maccy/OpenAI.swift` *(fails: no such module 'Defaults')*

------
https://chatgpt.com/codex/tasks/task_e_6840714a58ec8325ae662cf2922dcbdd