### PR TITLE
Add universal AI toggle shortcut

### DIFF
--- a/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -4,4 +4,5 @@ extension KeyboardShortcuts.Name {
   static let popup = Self("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
   static let pin = Self("pin", default: Shortcut(.p, modifiers: [.option]))
   static let delete = Self("delete", default: Shortcut(.delete, modifiers: [.option]))
+  static let toggleAI = Self("toggleAI", default: Shortcut(.a, modifiers: [.command, .option]))
 }

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -29,6 +29,7 @@ enum KeyChord: CaseIterable {
   case moveToPrevious
   case moveToFirst
   case openPreferences
+  case toggleAI
   case pinOrUnpin
   case selectCurrentItem
   case close
@@ -97,6 +98,8 @@ enum KeyChord: CaseIterable {
       self = .pinOrUnpin
     case (.comma, [.command]):
       self = .openPreferences
+    case (.a, [.command, .option]):
+      self = .toggleAI
     case (.return, _),
          (.keypadEnter, _):
       self = .selectCurrentItem

--- a/Maccy/Observables/Footer.swift
+++ b/Maccy/Observables/Footer.swift
@@ -1,4 +1,5 @@
 import Defaults
+import KeyboardShortcuts
 import SwiftUI
 
 @Observable
@@ -21,6 +22,7 @@ class Footer {
   init() { // swiftlint:disable:this function_body_length
     aiItem = FooterItem(
       title: Defaults[.aiEnabled] ? "ai_disable" : "ai_enable",
+      shortcuts: [KeyShortcut(key: .a, modifierFlags: [.command, .option])],
       help: Defaults[.aiEnabled] ? "ai_disable_tooltip" : "ai_enable_tooltip"
     ) {
       AppState.shared.toggleAI()
@@ -82,6 +84,10 @@ class Footer {
         AppState.shared.quit()
       }
     ]
+
+    KeyboardShortcuts.onKeyUp(for: .toggleAI) {
+      AppState.shared.toggleAI()
+    }
 
     Task { @MainActor in updateAIToggle() }
 

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -96,6 +96,9 @@ struct KeyHandlingView<Content: View>: View {
         case .openPreferences:
           appState.openPreferences()
           return .handled
+        case .toggleAI:
+          appState.toggleAI()
+          return .handled
         case .pinOrUnpin:
           appState.history.togglePin(appState.history.selectedItem)
           return .handled

--- a/Maccy/en.lproj/Localizable.strings
+++ b/Maccy/en.lproj/Localizable.strings
@@ -30,5 +30,5 @@
 "system_preferences_pane" = "Security & Privacy preferences";
 "ai_enable" = "Enable AI";
 "ai_disable" = "Disable AI";
-"ai_enable_tooltip" = "Enable AI features.";
-"ai_disable_tooltip" = "Disable AI features.";
+"ai_enable_tooltip" = "Enable AI features (⌘⌥A).";
+"ai_disable_tooltip" = "Disable AI features (⌘⌥A).";


### PR DESCRIPTION
## Summary
- expose new `KeyboardShortcuts.Name.toggleAI`
- register ⌘⌥A as a shortcut to enable/disable AI features
- handle the new key chord in popup
- show keyboard shortcut hint in English localization

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840724e7a308325a2f36be10377194b