### PR TITLE
Increase prompt editor size

### DIFF
--- a/Maccy/Settings/AdvancedSettingsPane.swift
+++ b/Maccy/Settings/AdvancedSettingsPane.swift
@@ -45,9 +45,10 @@ struct AdvancedSettingsPane: View {
         Text("OpenAIAPIKey", tableName: "AdvancedSettings")
         TextField("", text: $openAIKey)
       }
-      HStack {
+      HStack(alignment: .top) {
         Text("Prompt", tableName: "AdvancedSettings")
-        TextField("", text: $openAIPrompt)
+        TextEditor(text: $openAIPrompt)
+          .frame(height: 100)
       }
     }
     .frame(minWidth: 350, maxWidth: 450)


### PR DESCRIPTION
## Summary
- expand the prompt field in AdvancedSettingsPane by using a multiline `TextEditor`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684072a19490832588f8e0d6fe09e892