### PR TITLE
Fix missing Observation import

### DIFF
--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -2,6 +2,7 @@ import AppKit
 import Defaults
 import Foundation
 import Settings
+import Observation
 
 @Observable
 final class AppState: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- fix missing Observation import in `AppState`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68419e7f44248325932b9f5737198ed7