### PR TITLE
Fix prompts init and add missing icon name

### DIFF
--- a/Maccy/Extensions/NSImage+Names.swift
+++ b/Maccy/Extensions/NSImage+Names.swift
@@ -7,6 +7,7 @@ extension NSImage {
   static let pincircle = NSImage(systemSymbolName: "pin.circle", accessibilityDescription: "pin.cirlce")
   static let nosign = NSImage(systemSymbolName: "nosign", accessibilityDescription: "nosign")
   static let gearshape2 = NSImage(systemSymbolName: "gearshape.2", accessibilityDescription: "gearshape2")
+  static let textJustify = NSImage(systemSymbolName: "text.justify", accessibilityDescription: "text.justify")
 }
 
 extension NSImage.Name {

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -12,7 +12,8 @@ final class AppState: @unchecked Sendable {
   var popup: Popup
   var history: History
   var footer: Footer
-  var prompts: Prompts
+  @ObservationIgnored
+  var prompts = Prompts()
 
   var aiRequestRunning: Bool = false
 
@@ -67,7 +68,6 @@ final class AppState: @unchecked Sendable {
     history = History.shared
     footer = Footer()
     popup = Popup()
-    prompts = Prompts()
   }
 
   @MainActor
@@ -194,7 +194,7 @@ final class AppState: @unchecked Sendable {
           Settings.Pane(
             identifier: Settings.PaneIdentifier.prompts,
             title: NSLocalizedString("Title", tableName: "PromptsSettings", comment: ""),
-            toolbarIcon: NSImage.text.justify!
+            toolbarIcon: NSImage.textJustify!
           ) {
             PromptsSettingsPane()
           },

--- a/Maccy/Observables/Prompts.swift
+++ b/Maccy/Observables/Prompts.swift
@@ -3,7 +3,7 @@ import KeyboardShortcuts
 import Observation
 
 @Observable
-class Prompts {
+final class Prompts {
   init() {
     KeyboardShortcuts.onKeyUp(for: .prompt1) { Defaults[.activePromptIndex] = 0 }
     KeyboardShortcuts.onKeyUp(for: .prompt2) { Defaults[.activePromptIndex] = 1 }


### PR DESCRIPTION
## Summary
- initialize `prompts` property directly and ignore it for observation
- expose `Prompts` as a final class
- provide `textJustify` icon helper and use it for prompts settings pane

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68419fc8e3e88325924c23df911d2a6e