### PR TITLE
Fix Prompts property type

### DIFF
--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -13,7 +13,7 @@ final class AppState: @unchecked Sendable {
   var history: History
   var footer: Footer
   @ObservationIgnored
-  var prompts = Prompts()
+  var prompts: Prompts = .init()
 
   var aiRequestRunning: Bool = false
 


### PR DESCRIPTION
## Summary
- set `prompts` property to explicitly specify `Prompts` type

## Testing
- `swiftlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a133a1708325bed5aff878e1bcad