### PR TITLE
Fix default summarization prompt

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -63,7 +63,7 @@ extension Defaults.Keys {
   static let openAIPrompts = Key<[String]>(
     "openAIPrompts",
     default: [
-      "Summarize the copied text in 3 sentences.\nFocus on key facts only.",
+      "Summarize the copied text in 3 paragraphs.\nFocus on key facts only.",
       "Translate the copied text to Spanish.\nKeep formatting as close as possible.",
       "List main ideas as bullet points.\nUse one short phrase per bullet.",
       "Explain the meaning in simple terms.\nAvoid jargon or complex vocabulary.",


### PR DESCRIPTION
## Summary
- adjust the default summarization text to use three paragraphs instead of three sentences

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b2e9f9388325b77e3ef1dd1ca771