### PR TITLE
Fix text recognition language detection

### DIFF
--- a/Maccy/TextRecognition.swift
+++ b/Maccy/TextRecognition.swift
@@ -37,7 +37,7 @@ struct TextRecognition {
         let observations = request.results as? [VNRecognizedTextObservation] ?? []
         let candidates = observations.compactMap { $0.topCandidates(1).first }
         let text = candidates.map { $0.string }.joined(separator: "\n")
-        let language = NLLanguageRecognizer.dominantLanguage(for: text)?.rawValue ?? candidates.first?.languageCode
+        let language = NLLanguageRecognizer.dominantLanguage(for: text)?.rawValue
         continuation.resume(returning: (text, language))
       }
       request.recognitionLevel = .fast


### PR DESCRIPTION
## Summary
- fix build error in `TextRecognition.swift` by removing unavailable `languageCode` property

## Testing
- `swiftc Maccy/TextRecognition.swift -o /tmp/textrecognize` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_6842a731a22c8325816d51df5d0fb5c0