### PR TITLE
Fix text recognition languages fetch

### DIFF
--- a/Maccy/TextRecognition.swift
+++ b/Maccy/TextRecognition.swift
@@ -14,7 +14,7 @@ struct TextRecognition {
       throw TextRecognitionError.invalidImage
     }
 
-    let allLanguages = ["en"] + inputSourceLanguages()
+    let allLanguages = ["en"] + await inputSourceLanguages()
     let (text, detected) = try await recognize(cgImage: cgImage, languages: allLanguages)
 
     guard let detected, detected != "en" else {
@@ -52,6 +52,7 @@ struct TextRecognition {
     }
   }
 
+  @MainActor
   private static func inputSourceLanguages() -> [String] {
     var languages = Set<String>()
     if let list = TISCreateInputSourceList(nil, false)?.takeRetainedValue() as? [TISInputSource] {


### PR DESCRIPTION
## Summary
- ensure inputSourceLanguages runs on the main actor
- await when fetching languages before text recognition

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4a1867483258fa1252d99dab990