### PR TITLE
Fix YouTube transcript fetcher

### DIFF
--- a/Maccy/Youtube.swift
+++ b/Maccy/Youtube.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct YoutubeTranscriptFetcher {
   struct Transcript: Codable {
-    let text: String
+    let content: String
   }
 
   static func videoID(from url: String) -> String? {
@@ -26,16 +26,14 @@ struct YoutubeTranscriptFetcher {
   }
 
   static func fetchTranscript(for videoID: String, apiKey: String) async throws -> String {
-    let urlString = "https://supadata.supabase.co/rest/v1/transcripts?video_id=eq.\(videoID)&select=text"
+    let urlString = "https://api.supadata.ai/v1/youtube/transcript?videoId=\(videoID)&text=true"
     guard let url = URL(string: urlString) else { throw NSError(domain: "InvalidURL", code: -1) }
 
     var request = URLRequest(url: url)
-    request.addValue("application/json", forHTTPHeaderField: "Accept")
-    request.addValue(apiKey, forHTTPHeaderField: "apikey")
-    request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
 
     let (data, _) = try await URLSession.shared.data(for: request)
-    let transcripts = try JSONDecoder().decode([Transcript].self, from: data)
-    return transcripts.map { $0.text }.joined(separator: " ")
+    let transcript = try JSONDecoder().decode(Transcript.self, from: data)
+    return transcript.content
   }
 }


### PR DESCRIPTION
## Summary
- use new Supadata API endpoint for video transcripts

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c96ca3308325b6aa3254937df3ac