### PR TITLE
Fix variable redeclaration in OCR code

### DIFF
--- a/Maccy/TextRecognition.swift
+++ b/Maccy/TextRecognition.swift
@@ -15,10 +15,10 @@ struct TextRecognition {
     }
 
     // Start with automatic language detection without restricting languages
-    let (initialText, detected) = try await recognize(cgImage: cgImage, languages: [])
+    let (initialText, _) = try await recognize(cgImage: cgImage, languages: [])
     let inputLanguages = await inputSourceLanguages()
     let allLanguages = ["en"] + inputLanguages
-    let (text, detected) = try await recognize(cgImage: cgImage, languages: allLanguages)
+    let (_, detected) = try await recognize(cgImage: cgImage, languages: allLanguages)
 
     // If language couldn't be detected, just return whatever was recognised
     guard let detected else { return initialText }


### PR DESCRIPTION
## Summary
- resolve Swift compile error caused by redefining `detected`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cbb43314832597e714ea0ea74f3c