### PR TITLE
Fix broken TextRecognition.swift

### DIFF
--- a/Maccy/TextRecognition.swift
+++ b/Maccy/TextRecognition.swift
@@ -10,35 +10,29 @@ enum TextRecognitionError: Error {
 }
 
 struct TextRecognition {
-    
-    /// Recognizes text in the given image data.
-    /// - Parameter imageData: The Data of the image to process.
-    /// - Returns: The recognized text as a String.
-    /// - Throws: A `TextRecognitionError` if the image is invalid or recognition fails.
     static func recognize(imageData: Data) async throws -> String {
         guard let image = NSImage(data: imageData),
               let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             throw TextRecognitionError.invalidImage
         }
 
-        // 1. Get the user's configured keyboard input languages.
+        let (initialText, _) = try await recognize(cgImage: cgImage, languages: [])
         let inputLanguages = await inputSourceLanguages()
-        
-        // 2. Create a set of languages for recognition.
-        // We include English ("en-US") and Russian ("ru-RU") as strong defaults,
-        // plus any other languages from the user's system.
-        // A Set automatically handles duplicates.
-        var potentialLanguages = Set(inputLanguages)
-        potentialLanguages.insert("en-US")
-        potentialLanguages.insert("ru-RU")
+        let allLanguages = ["en"] + inputLanguages
+        let (_, detected) = try await recognize(cgImage: cgImage, languages: allLanguages)
 
-        // 3. Perform a single, accurate recognition request.
-        let recognizedText = try await performRecognition(on: cgImage, withLanguages: Array(potentialLanguages))
-        return recognizedText
+        guard let detected else { return initialText }
+
+        var languages = await inputSourceLanguages()
+        languages.append("en")
+        languages.append(detected)
+        let finalLanguages = Array(Set(languages))
+
+        let (finalText, _) = try await recognize(cgImage: cgImage, languages: finalLanguages)
+        return finalText
     }
 
-    /// Performs the actual Vision text recognition.
-    private static func performRecognition(on cgImage: CGImage, withLanguages languages: [String]) async throws -> String {
+    private static func recognize(cgImage: CGImage, languages: [String]) async throws -> (String, String?) {
         try await withCheckedThrowingContinuation { continuation in
             let request = VNRecognizeTextRequest { request, error in
                 if let error = error {
@@ -46,39 +40,17 @@ struct TextRecognition {
                     return
                 }
 
-                guard let observations = request.results as? [VNRecognizedTextObservation] else {
-                    continuation.resume(returning: "")
-                    return
-                }
-
-                let recognizedStrings = observations.compactMap { observation in
-                    // Return the most confident recognition candidate.
-                    observation.topCandidates(1).first?.string
-                }
-
-        let observations = request.results as? [VNRecognizedTextObservation] ?? []
-        let candidates = observations.compactMap { $0.topCandidates(1).first }
-        let text = candidates.map { $0.string }.joined(separator: "\n")
-        let language = NLLanguageRecognizer.dominantLanguage(for: text)?.rawValue
-        continuation.resume(returning: (text, language))
-      }
-      request.recognitionLevel = .accurate
-      request.usesLanguageCorrection = true
-      if !languages.isEmpty {
-        request.recognitionLanguages = languages
-      }
-                continuation.resume(returning: recognizedStrings.joined(separator: "\n"))
+                let observations = request.results as? [VNRecognizedTextObservation] ?? []
+                let candidates = observations.compactMap { $0.topCandidates(1).first }
+                let text = candidates.map { $0.string }.joined(separator: "\n")
+                let language = NLLanguageRecognizer.dominantLanguage(for: text)?.rawValue
+                continuation.resume(returning: (text, language))
             }
-
-            // KEY FIX 1: Use .accurate for better language support, including Cyrillic.
             request.recognitionLevel = .accurate
-            
-            // KEY FIX 2: Provide the list of potential languages to the request.
-            // Vision uses this list to improve accuracy.
-            request.recognitionLanguages = languages
-            
-            // Optional: You can uncomment this to check if your OS version supports the languages.
-            // printSupportedLanguages(for: request)
+            request.usesLanguageCorrection = true
+            if !languages.isEmpty {
+                request.recognitionLanguages = languages
+            }
 
             let handler = VNImageRequestHandler(cgImage: cgImage)
             do {
@@ -89,26 +61,23 @@ struct TextRecognition {
         }
     }
 
-    /// Retrieves the user's enabled keyboard input source languages (e.g., "en", "ru").
     @MainActor
     private static func inputSourceLanguages() -> [String] {
-        guard let list = TISCreateInputSourceList(nil, false)?.takeRetainedValue() as? [TISInputSource],
-              let sources = list as? [TISInputSource] else { return [] }
-        
         var languages = Set<String>()
-        for source in sources {
-            // We want languages associated with this input source (keyboard)
-            guard let pointer = TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages) else { continue }
-            let langArray = Unmanaged<CFArray>.fromOpaque(pointer).takeUnretainedValue() as? [String]
-            
-            if let langArray = langArray {
-                languages.formUnion(langArray)
+        if let list = TISCreateInputSourceList(nil, false)?.takeRetainedValue() as? [TISInputSource] {
+            for source in list {
+                if let value = TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages) {
+                    let array = Unmanaged<CFArray>.fromOpaque(value).takeUnretainedValue() as NSArray
+                    for case let lang as String in array {
+                        languages.insert(lang)
+                    }
+                }
             }
         }
+        languages.formUnion(Locale.preferredLanguages)
         return Array(languages)
     }
-    
-    /// A helper utility to print which languages are actually supported on the current device.
+
     private static func printSupportedLanguages(for request: VNRecognizeTextRequest) {
         do {
             let supported = try request.supportedRecognitionLanguages()
@@ -117,8 +86,4 @@ struct TextRecognition {
             print("❌ Could not get supported languages: \(error)")
         }
     }
-    languages.formUnion(Locale.preferredLanguages)
-    return Array(languages)
-  }
-master
 }


### PR DESCRIPTION
## Summary
- restore valid implementation for TextRecognition

## Testing
- `swiftc -o /tmp/test Maccy/TextRecognition.swift` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_6846aa9ea2788325ba0d6f3433135786