### PR TITLE
Fix preferences pane width

### DIFF
--- a/Maccy/Settings/AdvancedSettingsPane.swift
+++ b/Maccy/Settings/AdvancedSettingsPane.swift
@@ -16,7 +16,7 @@ struct AdvancedSettingsPane: View {
         Text("ClearSystemClipboard", tableName: "AdvancedSettings")
       }.help(Text("ClearSystemClipboardTooltip", tableName: "AdvancedSettings"))
     }
-    .frame(minWidth: 350, maxWidth: 450)
+    .frame(width: 650)
     .padding()
   }
 }

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -18,7 +18,7 @@ struct GeneralSettingsPane: View {
   @State private var updater = SoftwareUpdater()
 
   var body: some View {
-    Settings.Container(contentWidth: 450) {
+    Settings.Container(contentWidth: 650) {
       Settings.Section(title: "", bottomDivider: true) {
         LaunchAtLogin.Toggle {
           Text("LaunchAtLogin", tableName: "GeneralSettings")

--- a/Maccy/Settings/IgnoreSettingsPane.swift
+++ b/Maccy/Settings/IgnoreSettingsPane.swift
@@ -16,7 +16,7 @@ struct IgnoreSettingsPane: View {
           Text("RegexpTab", tableName: "IgnoreSettings")
         }
     }
-    .frame(maxWidth: 500, minHeight: 400)
+    .frame(width: 650, minHeight: 400)
     .padding()
   }
 }

--- a/Maccy/Settings/PinsSettingsPane.swift
+++ b/Maccy/Settings/PinsSettingsPane.swift
@@ -68,7 +68,7 @@ struct PinsSettingsPane: View {
         .foregroundStyle(.gray)
         .controlSize(.small)
     }
-    .frame(minWidth: 500, minHeight: 400)
+    .frame(width: 650, minHeight: 400)
     .padding()
   }
 }

--- a/Maccy/Settings/PromptsSettingsPane.swift
+++ b/Maccy/Settings/PromptsSettingsPane.swift
@@ -30,7 +30,7 @@ struct PromptsSettingsPane: View {
         .foregroundStyle(.gray)
         .controlSize(.small)
     }
-    .frame(minWidth: 500, maxWidth: 600, minHeight: 400)
+    .frame(width: 650, minHeight: 400)
     .padding()
   }
 }

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -69,7 +69,7 @@ struct StorageSettingsPane: View {
   }()
 
   var body: some View {
-    Settings.Container(contentWidth: 450) {
+    Settings.Container(contentWidth: 650) {
       Settings.Section(
         bottomDivider: true,
         label: { Text("Save", tableName: "StorageSettings") }

--- a/Maccy/Settings/SubscriptionSettingsPane.swift
+++ b/Maccy/Settings/SubscriptionSettingsPane.swift
@@ -37,6 +37,6 @@ struct SubscriptionSettingsPane: View {
         set: { showSubscriptionView = $0 }
       ), fromOnboarding: false)
     }
-    .frame(width: 400, height: 200)
+    .frame(width: 650, height: 200)
   }
-} 
+}


### PR DESCRIPTION
## Summary
- keep preferences window a consistent width when switching tabs

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68499b95cff08325b9c4634678376fae